### PR TITLE
Swagger index.htmlの言語設定を日本語に変更

### DIFF
--- a/api/index.html
+++ b/api/index.html
@@ -1,6 +1,6 @@
 <!-- HTML for static distribution bundle build -->
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
   <head>
     <meta charset="UTF-8">
     <title>Swagger UI</title>


### PR DESCRIPTION
- Swagger index.htmlの言語設定が`en`になっていたため`ja`に変更